### PR TITLE
Testing/eb 'success' & 'error' response object translations

### DIFF
--- a/cypress/fixtures/errorDuplicate.json
+++ b/cypress/fixtures/errorDuplicate.json
@@ -1,3 +1,3 @@
 {
-  "error": "elisebeall@gmail.com is already subscribed to receive election notifications."
+  "error": "elisebeall@gmail.com is already subscribed to receive election notifications"
 }

--- a/cypress/fixtures/errorDuplicateES.json
+++ b/cypress/fixtures/errorDuplicateES.json
@@ -1,3 +1,3 @@
 {
-  "error": "This is a placeholder until translations are complete."
+  "error": "bernie2020denver@gmail.com ya está suscrito para recibir notificaciones electorales"
 }

--- a/cypress/fixtures/errorNotSubscribed.json
+++ b/cypress/fixtures/errorNotSubscribed.json
@@ -1,3 +1,3 @@
 {
-  "error": "elisebeall@gmail.com is not currently subscribed to receive election notifications."
+  "error": "This email is not currently registered to receive emails"
 }

--- a/cypress/fixtures/errorNotSubscribedES.json
+++ b/cypress/fixtures/errorNotSubscribedES.json
@@ -1,3 +1,3 @@
 {
-  "error": "This is a placeholder until translations are complete."
+  "error": "Este correo electrónico no está registrado actualmente para recibir correos electrónicos"
 }

--- a/cypress/fixtures/successES.json
+++ b/cypress/fixtures/successES.json
@@ -1,3 +1,3 @@
 {
-    "success": "This is a placeholder until translations are complete."
+    "success": "Ahora usted esta registrado para recibir notificaciones sobre las proximas elecciones en su estado. Un correo electronico do confirmacion ha sido enviado"
 }

--- a/cypress/fixtures/successES.json
+++ b/cypress/fixtures/successES.json
@@ -1,3 +1,3 @@
 {
-    "success": "Ahora usted esta registrado para recibir notificaciones sobre las proximas elecciones en su estado. Un correo electronico do confirmacion ha sido enviado"
+    "success": "Ahora usted esta registrado para recibir notificaciones sobre las proximas elecciones en su estado. Un correo electronico do confirmacion ha sido enviado bernie2020denver@gmail.com"
 }

--- a/cypress/fixtures/successUnsubscribeES.json
+++ b/cypress/fixtures/successUnsubscribeES.json
@@ -1,3 +1,3 @@
 {
-  "success": "This is a placeholder until translations are complete."
+  "success": "Te has dado de baja con éxito de Mi Voto, la lista de correo de Mi Voz. Ya no recibirás notificaciones por correo electrónico en bernie2020@gmail.com"
 }

--- a/cypress/integration/email-notification-form-spec.js
+++ b/cypress/integration/email-notification-form-spec.js
@@ -48,7 +48,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
         .get(`select[id=state_name]`).should('have.value', `${user1.state_name}`)
         .get('input[id=email]').type(user1.email)
         .get(`input[value="${user1.email}"]`).should('have.value', `${user1.email}`)
-        .get('input[id=english]').click()
+        .get(`input[value=${user1.language}]`).click()
         .get(`input[value=${user1.language}]`).should('have.value', `${user1.language}`)
         .get('input[id=agree_to_emails]').should('have.value', 'false')
         .get('input[id=agree_to_emails]').click()
@@ -92,7 +92,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
           .get('input[id=email]').type(user1.email)
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', english['emailNotificationForm.missingLanguage'])
-          .get('input[id=english]').click()
+          .get(`input[value=${user1.language}]`).click()
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', english['emailNotificationForm.missingCheckbox'])
           .get('input[id=agree_to_emails]').click()
@@ -147,7 +147,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
           .get('.missing-input-message').should('contain', '')
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', english['emailNotificationForm.missingLanguage'])
-          .get('input[id=english]').click()
+          .get(`input[value=${user1.language}]`).click()
           .get('.missing-input-message').should('contain', '')
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', english['emailNotificationForm.missingCheckbox'])
@@ -179,7 +179,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
           .get('.missing-input-message').should('contain', '')
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', spanish['emailNotificationForm.missingLanguage'])
-          .get('input[id=english]').click()
+          .get(`input[value=${user1.language}]`).click()
           .get('.missing-input-message').should('contain', '')
           .get('.submit-button').click()
           .get('.missing-input-message-container').should('contain', spanish['emailNotificationForm.missingCheckbox'])
@@ -201,7 +201,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
         .get('input[id=last_name]').type(user1.last_name)
         .get('select[id=state_name]').select(user1.state_name)
         .get('input[id=email]').type(user1.email)
-        .get('input[id=english]').click()
+        .get(`input[value=${user1.language}]`).click()
         .get('input[id=agree_to_emails]').click()
         .get('.submit-button').click()
         .wait('@successfulPost')
@@ -228,7 +228,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
         .get('input[id=last_name]').type(user3.last_name)
         .get('select[id=state_name]').select(user3.state_name)
         .get('input[id=email]').type(user3.email)
-        .get('input[id=english]').click()
+        .get(`input[value=${user3.language}]`).click()
         .get('input[id=agree_to_emails]').click()
         .get('.submit-button').click()
         .get('.loading-icon').should('be.visible')
@@ -331,7 +331,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
     })
   });
 
-  it('Should display an error image & error message if the server can\'t complete the request', () => {
+  it('Should display an error image & error message, in both English & Spanish, if the server can\'t complete the request', () => {
     cy.intercept('POST', 'http://localhost:3001/api/v1/users', {statusCode: 500}).as('getServerFailure')
 
     cy.fixture('user1.json').as('user1').then((user1) => {
@@ -339,7 +339,7 @@ describe('Mi Voz, Mi Voto email notification form user flow', () => {
         .get('input[id=last_name]').type(user1.last_name)
         .get('select[id=state_name]').select(user1.state_name)
         .get('input[id=email]').type(user1.email)
-        .get('input[id=english]').click()
+        .get(`input[value=${user1.language}]`).click()
         .get('input[id=agree_to_emails]').click()
         .get('.submit-button').click()
         .wait('@getServerFailure')

--- a/cypress/integration/unsubscribe-form-spec.js
+++ b/cypress/integration/unsubscribe-form-spec.js
@@ -131,8 +131,39 @@ describe('Unsubscribe form user flow', () => {
     })
   });
 
-  it('Should be able to go to the main page', () => {
-    cy.get('.vote-image').click()
-      .url().should('contain', '/')
+  it('Should, if the server can\'t complete the request, display an error image, a message in English, & then be able to navigate back to the main page', () => {
+    cy.intercept('DELETE', 'http://localhost:3001/api/v1/users', {statusCode: 500}).as('getServerFailure')
+
+    cy.fixture('user1.json').as('user1').then((user1) => {
+      cy.get('input[id=email]').type(user1.email)
+        .get('.unsubscribe-button').click()
+        .wait('@getServerFailure')
+    })
+
+    cy.fixture('english.json').as('english').then((english) => {
+      cy.get('.error-image').should('be.visible')
+        .get('h3[class=error-text]').should('contain', english['error.sorryMessage'])
+        .get('.error-container')
+        .get('.home-button').should('contain', english['pageNotFound.button']).click()
+        .url().should('contain', '/')
+    })
+  });
+
+  it('Should, if the server can\'t complete the request, display an error image, a message in Spanish, & then be able to navigate back to the main page', () => {
+    cy.intercept('DELETE', 'http://localhost:3001/api/v1/users', {statusCode: 500}).as('getServerFailure')
+
+    cy.get('.en-espanol-button').select('Español')
+    cy.fixture('user1.json').as('user1').then((user1) => {
+      cy.get('input[id=email]').type(user1.email)
+        .get('.unsubscribe-button').click()
+        .wait('@getServerFailure')
+    })
+
+    cy.fixture('spanish.json').as('spanish').then((spanish) => {
+      cy.get('.error-image').should('be.visible')
+        .get('h3[class=error-text]').should('contain', spanish['error.sorryMessage'])
+        .get('.home-button').should('contain', spanish['pageNotFound.button']).click()
+        .url().should('contain', '/')
+    })
   });
 });

--- a/src/Components/Error/Error.js
+++ b/src/Components/Error/Error.js
@@ -16,7 +16,7 @@ const Error = ({ error }) => {
           defaultMessage="We're sorry, please try again." />
       </h3>
       <h4 className="error-text">{error}</h4>
-      <button onClick={() => navigate('/')}>
+      <button className="home-button" onClick={() => navigate('/')}>
         <FormattedMessage
           id="pageNotFound.button"
           defaultMessage="Home" />


### PR DESCRIPTION
# [Mi Voz, Mi Voto] 🗳

- [x] Refactor PR [⚙️]
- [x] Testing PR [🧑‍💻]

## **What (if any) features are you implementing?**
 - Added translation fixtures of 'success' & 'error' response objects
 - Closes #52 
 - Added testing of error component if the server throws a 500 error while FE attempts to DELETE a subscriber
 
## **What (if anything) did you refactor?**
 - Refactored the language selection tests to select an option based of the user fixture.

## **Were there any issues that arose?**
 - [Testing iframes is tough stuff](https://www.cypress.io/blog/2020/02/12/working-with-iframes-in-cypress/)

## **Is there anything needs to be prioritized/errors to be addressed?**
 - (NA)

## **Goals? Next steps?**
 - Attempt to test embedded iframes from vote.org

## **⬇︎ Current Screenshots ⬇︎**

![Screen Shot 2022-02-16 at 16 13 56](https://user-images.githubusercontent.com/724355/154385183-d4c296c6-336d-46ce-89a0-3b14c33ae4dd.png)

![Screen Shot 2022-02-16 at 16 12 12](https://user-images.githubusercontent.com/724355/154385158-e3512392-6d00-409f-9100-868bf400dd81.png)

